### PR TITLE
Address 'nlCHECK' Errors and Warnings

### DIFF
--- a/src/nlfsm-driver.cpp
+++ b/src/nlfsm-driver.cpp
@@ -132,8 +132,6 @@ Driver::Driver(Machine &inMachine, Delegate::Base *inDelegate) :
 void
 Driver::SetMachine(Machine &inMachine)
 {
-    nlCHECK(&inMachine != NULL);
-
     mMachine = &inMachine;
 }
 

--- a/src/nlfsm-machine.cpp
+++ b/src/nlfsm-machine.cpp
@@ -265,9 +265,6 @@ Machine::FindTransition(const State & inState, const Event & inEvent) const
     const Transition * end = mFirstTransition + mCount;
     const FindTransitionPredicate theFinder(inState, inEvent);
 
-    nlCHECK(&inState != NULL);
-    nlCHECK(&inEvent != NULL);
-
     while ((start != end) && !bool(theFinder(start))) {
         ++start;
     }


### PR DESCRIPTION
This addresses #2 by removing three superfluous `nlCHECK` macro invocations against reference type parameters which will never be null.